### PR TITLE
Stop bibliography margin note from incrementing lists

### DIFF
--- a/src/assets/css/marginnote-bibliography.css
+++ b/src/assets/css/marginnote-bibliography.css
@@ -5,4 +5,5 @@ span.inline-bib > span.inline-bib-entry {
   display: list-item;
   list-style-position: outside;
   list-style-type: disclosure-closed;
+  counter-increment: list-item 0;
 }


### PR DESCRIPTION
 Adds :   `counter-increment: list-item 0; `
Preventing bibliography margin notes from incrementing list counters unintentionally, due to being called as :
 `display: list-item`; (allows for triangle styling in margin).