### PR TITLE
Fix several repo paths in the tutorial

### DIFF
--- a/src/chapters/2-language.md
+++ b/src/chapters/2-language.md
@@ -369,9 +369,9 @@ You can find them in the Reluplex paper [@katz2017reluplex] ([arXiv](https://arx
 ## Exercise #4 (⭑⭑⭑). Your first independent Vehicle specification
 
 1.  Clone the [tutorial repository](https://github.com/vehicle-lang/vehicle-tutorial).
-2.  Find the `iris_model.onnx` model under `exercises/chapter2/iris-dataset`.
+2.  Find the `iris_model.onnx` model under `exercises/iris-dataset/`.
     This model was trained on the famous [Iris flower data set](https://en.wikipedia.org/wiki/Iris_flower_data_set).
-3.  Find the Iris data set files `iris_test_data.idx` and `iris_test_labels.idx` under `exercises/chapter2/iris-dataset`.
+3.  Find the Iris data set files `iris_test_data.idx` and `iris_test_labels.idx` under `exercises/iris-dataset/`.
 4.  Examine the data set and try to define a few "obvious properties" that should hold for the model.
     You a free to look at the Wikipedia page for the [Iris flower data set](https://en.wikipedia.org/wiki/Iris_flower_data_set) or consult other sources.
 5.  Write those properties as a Vehicle specification.

--- a/src/chapters/3-proving-robustness.md
+++ b/src/chapters/3-proving-robustness.md
@@ -244,7 +244,7 @@ Try experimenting with different values of $\epsilon$, for example, try
 (_This exercise is technically very simple, but the required number of experiments may take a few hours to run. We recommend you run it at home rather than during the live exercise sessions_).
 
 The previous exercise could be transformed into a proper empirical evaluation of robustness of the model for the data set.
-To do this, include more than 2 images into your `idx` file.  A script for generating `idx` files is available [in the supporting materials](https://github.com/vehicle-lang/tutorial/tree/tutorial/exercises/chapter3/MNIST-complete).
+To do this, include more than 2 images into your `idx` file.  A script for generating `idx` files is available [in the supporting materials](https://github.com/vehicle-lang/tutorial/tree/tutorial/exercises/MNIST-complete).
 
 Assuming you created an `idx` file with, for example, 500 images, run _Vehicle_ on this file, and collect statistics for $\epsilon = 0.005, 0.01, 0.05, 0.1, 0.5$. You should be able to populate a table that looks like this:
 
@@ -288,7 +288,7 @@ Re-define the _classification_ and _standard robustness_ properties by using som
 
 ## Exercise #7 (⭑) Practicing to write property specifications
 
-To test your understanding of the robustness property, try completing the robustness verification in [this file](https://github.com/vehicle-lang/tutorial/tree/tutorial/exercises/chapter3/MNIST-incomplete).
+To test your understanding of the robustness property, try completing the robustness verification in [this file](https://github.com/vehicle-lang/tutorial/tree/tutorial/exercises/MNIST-incomplete).
 
 ## Exercise #8 (⭑⭑⭑): Conduct a complete "training - verification" experiment from start to finish
 
@@ -299,6 +299,6 @@ We will work with the [Fashion MNIST data set](https://www.tensorflow.org/datase
 Either:
 
 - download the data set, train a model from scratch, generate `onnx` and `idx` files; or
-- obtain the model and `idx` files directly from the directory with [the supporting materials](https://github.com/vehicle-lang/tutorial/tree/tutorial/exercises/chapter3/FMNIST)
+- obtain the model and `idx` files directly from the directory with [the supporting materials](https://github.com/vehicle-lang/tutorial/tree/tutorial/exercises/FMNIST)
 
 Once this is done, define the spec and verify its robustness. Experiment with different values of $\epsilon$ and different definitions of robustness.


### PR DESCRIPTION
There are also broken paths in `README.md`, however all that file looks like an outdated version of the tutorial so I don't know if I should also fix them or not